### PR TITLE
Migrate Sleed to Manifest V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Sleed",
-  "version": "2.0.0",
-  "manifest_version": 2,
+  "version": "2.1.0",
+  "manifest_version": 3,
   "content_scripts": [
     {
       "matches": [
@@ -15,7 +15,7 @@
   "permissions": [
     "activeTab"
   ],
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_title": "Sleed"
   },

--- a/popup.html
+++ b/popup.html
@@ -1,48 +1,74 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8" />
     <style>
       * {
-          box-sizing: border-box;
+        box-sizing: border-box;
       }
+
       body {
-        border: 0;
+        width: 420px;
         margin: 0;
-        padding: 10px;
-        display: flex;
-        flex-direction: column;
+        padding: 6px;
         font-family: monospace;
       }
-      input {
-          flex: 1;
-      }
-      #display {
-        width: 100px;
+
+      .header {
         display: flex;
-        align-items:center;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 6px;
+      }
+
+      #display {
+        flex: 0 0 80px;
+        white-space: nowrap;
+        padding: 4px 6px;
+        border-radius: 3px;
         background: black;
         color: white;
-        border-radius: 3px;
-        margin-right: 4px;
-        padding: 5px
+        text-align: center;
+        font-size: 11px;
       }
-      .header {
-        margin: 4px 0;
-        border-radius: 3px;
-        background: #e9e9e9;
+
+      #slider {
+        flex: 1;
+        min-width: 0;
+        margin: 0;
+      }
+
+      .buttons {
         display: flex;
-        justify-content: center;
-        align-items:center;
-          padding-right: 5px
+        gap: 4px;
+        flex-wrap: nowrap;
+      }
+
+      button {
+        flex: 1;
+        min-width: 0;
+        padding: 3px 2px;
+        font-size: 10px;
+        cursor: pointer;
       }
     </style>
   </head>
+
   <body>
     <div class="header">
       <div id="display">Speed: 1</div>
-      <input id="slider" type="range" min="0.25" max="10" value="1" step="0.25" />
+
+      <input
+        id="slider"
+        type="range"
+        min="0.25"
+        max="10"
+        value="1"
+        step="0.25"
+      />
     </div>
-    <div>
+
+    <div class="buttons">
       <button id="1">1</button>
       <button id="1.5">1.5</button>
       <button id="2">2</button>
@@ -55,6 +81,7 @@
       <button id="3.75">3.75</button>
       <button id="4">4</button>
     </div>
+
     <script src="popup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Migrates Sleed from Manifest V2 to Manifest V3 so it works in current Chromium-based browsers, including Brave and Chrome.

## Changes

- Updated `manifest_version` from 2 to 3
- Replaced `browser_action` with `action`
- Preserved the existing content script and popup behavior
- Fixed the popup width and layout for current Chromium browsers
- Kept all speed presets on one row
- Preserved the full slider and speed display

## Testing

Tested manually in Brave with:

- YouTube videos
- HTML5 video playback
- Preset speed buttons
- Slider values from `0.25` to `10`
- Extension reloads
- No errors shown in `brave://extensions`